### PR TITLE
Secure permissions on data directory

### DIFF
--- a/src/main/java/org/multibit/ApplicationDataDirectoryLocator.java
+++ b/src/main/java/org/multibit/ApplicationDataDirectoryLocator.java
@@ -100,6 +100,11 @@ public class ApplicationDataDirectoryLocator {
                 if (!created) {
                     log.error("Could not create the application data directory of '" + applicationDataDirectory + "'");
                 }
+                // Set directory to be readable only by owner on opperating systems that support this.
+                boolean permissionsSet = directory.setReadable(false, false) && directory.setReadable(true, true);
+                if (!permissionsSet) {
+                    log.error("Could not set permissions on the the application data directory '" + applicationDataDirectory + "'");
+                }
             }
         }
 


### PR DESCRIPTION
This is untested, just an example to address jim618/multibit/issues/430

First we set to _not world readable_, then we set to be _readable by owner only_.